### PR TITLE
Add architecture option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ const options: Plug.Options = {
   // linux: "https://example.com/some/path/libtest_lib.so"
 };
 
+// Also you can specify for certain architecture
+const options: Plug.Options = {
+  name: "test_lib",
+  urls: {
+    darwin: {
+      aarch64: `https://example.com/some/path/libtest_lib_aarch64.dylib`,
+      x86_64: `https://example.com/some/path/libtest_lib_x86_64.dylib`,
+    },
+    windows: `https://example.com/some/path/test_lib.dll`,
+    linux: `https://example.com/some/path/libtest_lib.so`,
+  },
+};
+
 // Drop-in replacement for `Deno.dlopen`
 const library = await Plug.prepare(options, {
   noop: { parameters: [], result: "void" },


### PR DESCRIPTION
Add arch options for `CrossOptions.urls`.

Without this option, the user who wants to support universal macOS must create universal lib which is approximately 2x bigger than lib for one architecture.
For example, in [`deno_installer`](https://github.com/marc2332/deno_installer), [the original `.dylib` file](https://github.com/marc2332/deno_installer/releases/tag/0.1.2)(4.98MB) which only supports `x86_64` arch becomes 2x bigger [when it supports both architecture](https://github.com/hyp3rflow/deno_installer/releases/tag/0.0.3-test) (x86_64 + aarch64, 10.2 MB) 