### PR TITLE
fix: ensure full cache path

### DIFF
--- a/download.ts
+++ b/download.ts
@@ -223,6 +223,8 @@ export async function download(options: FetchOptions): Promise<string> {
     ? await isFile(cacheFilePath)
     : setting === "only" || setting !== "reloadAll";
 
+  await ensureDir(cacheBasePath);
+
   if (!cached) {
     const meta = { url };
     switch (url.protocol) {


### PR DESCRIPTION
This fixes the first time creation of certain paths. I encountered this when webview_deno on windows copied files while I had a fully cleared cache (e.g. no `DENO_DIR/plug` directory)