### PR TITLE
docs(README, mod.ts): update code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import { dlopen } from "https://deno.land/x/plug/mod.ts";
 // on operating system:
 // * darwin: "https://example.com/some/path/libexample.dylib"
 // * windows: "https://example.com/some/path/example.dll"
-// * unix: "https://example.com/some/path/libexample.so"
+// * linux: "https://example.com/some/path/libexample.so"
 const library = await dlopen("https://example.com/some/path/", {
   noop: { parameters: [], result: "void" },
 });
@@ -40,7 +40,7 @@ const options: FetchOptions = {
   // Becomes:
   // darwin: "https://example.com/some/path/libexample.dylib"
   // windows: "https://example.com/some/path/example.dll"
-  // unix: "https://example.com/some/path/libexample.so"
+  // linux: "https://example.com/some/path/libexample.so"
 };
 
 const library = await dlopen(options, {

--- a/mod.ts
+++ b/mod.ts
@@ -13,7 +13,7 @@
  * // on operating system:
  * // * darwin: "https://example.com/some/path/libexample.dylib"
  * // * windows: "https://example.com/some/path/example.dll"
- * // * unix: "https://example.com/some/path/libexample.so"
+ * // * linux: "https://example.com/some/path/libexample.so"
  * const library = await dlopen("https://example.com/some/path/", {
  *   noop: { parameters: [], result: "void" },
  * });
@@ -32,7 +32,7 @@
  *   // Becomes:
  *   // darwin: "https://example.com/some/path/libexample.dylib"
  *   // windows: "https://example.com/some/path/example.dll"
- *   // unix: "https://example.com/some/path/libexample.so"
+ *   // linux: "https://example.com/some/path/libexample.so"
  * };
  *
  * const library = await dlopen(options, {
@@ -55,7 +55,7 @@
  *       x86_64: `https://example.com/some/path/libexample.x86_64.dylib`,
  *     },
  *     windows: `https://example.com/some/path/example.dll`,
- *     unix: `https://example.com/some/path/libexample.so`,
+ *     linux: `https://example.com/some/path/libexample.so`,
  *   },
  * };
  *


### PR DESCRIPTION
The explanation of how to use mod.ts and READEME is outdated.
When I look at the implementation of the source code, I see getCrossOption, I see OsRecord, and I see a test called download_test.ts,
It does not expect the string "unix" to come in.

OsRecord is defined as below, though,
```ts:types.ts
type OsRecord<T> = { [os in typeof Deno.build.os]: T };
```

When I look at https://deno.land/api@v1.37.1?s=Deno.build of the document, the definition of "unix" is not present.
"unix" should be changed to linux.
